### PR TITLE
generate changelog based on user defined input

### DIFF
--- a/build/tools/changelog.sh
+++ b/build/tools/changelog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2017 crDroid Android Project
+# Copyright (C) 2017-2018 crDroid Android Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ fi
 
 touch $Changelog
 
-for i in $(seq 10);
+echo "For how many days do you want to generate changelog? (🕑 timeout 15 seconds - default to 7 days)"
+read -r -t 15 days || days=7
+
+for i in $(seq $days);
 do
 export After_Date=`date --date="$i days ago" +%m-%d-%Y`
 k=$(expr $i - 1)

--- a/build/tools/changelog.sh
+++ b/build/tools/changelog.sh
@@ -29,12 +29,11 @@ touch $Changelog
 if [ -z $changelog_days ];then
 	changelog_days=10
 else
-	if [ $changelog_days > 30 ]; then
+	if (($changelog_days > 30 )); then
         echo "Changelog can not generated for more then 30 days. For how many days do you want to generate changelog again? (🕑 timeout 15 seconds - default to 10 days)"
         read -r -t 15 changelog_days || changelog_days=10
 	fi
 fi
-echo $changelog_days
 
 for i in $(seq $changelog_days);
 do

--- a/build/tools/changelog.sh
+++ b/build/tools/changelog.sh
@@ -24,10 +24,19 @@ fi
 
 touch $Changelog
 
-echo "For how many days do you want to generate changelog? (🕑 timeout 15 seconds - default to 7 days)"
-read -r -t 15 days || days=7
+# define changelog_days using 'export changelog_days=10'
+# this can be done before intiate build environment (. build/envsetup.sh) 
+if [ -z $changelog_days ];then
+	changelog_days=10
+else
+	if [ $changelog_days > 30 ]; then
+        echo "Changelog can not generated for more then 30 days. For how many days do you want to generate changelog again? (🕑 timeout 15 seconds - default to 10 days)"
+        read -r -t 15 changelog_days || changelog_days=10
+	fi
+fi
+echo $changelog_days
 
-for i in $(seq $days);
+for i in $(seq $changelog_days);
 do
 export After_Date=`date --date="$i days ago" +%m-%d-%Y`
 k=$(expr $i - 1)


### PR DESCRIPTION
when changelog generation script starts, the user will be prompted with a messages asking for how many days to generate the changelog
default value is 7 days and is timing out to 15 seconds if no input is detected

improvement idea: maybe transform this in a flag also, so that if value is preset, message won't show