### PR TITLE
init: smart charging: chown batt slate mode

### DIFF
--- a/prebuilt/common/etc/init/init.crdroid.rc
+++ b/prebuilt/common/etc/init/init.crdroid.rc
@@ -1,4 +1,5 @@
 on post-fs-data
+    chown system system /sys/class/power_supply/battery/batt_slate_mode
     chown system system /sys/class/power_supply/battery/battery_charging_enabled
     chown system system /sys/class/power_supply/battery/charging_enabled
     chown system system /sys/class/power_supply/battery/input_suspend


### PR DESCRIPTION
* Most Samsung Devices have this node for resuming and stopping the charging..

Proper Values to use for this node:
- Suspend = 1
- Resume = 0