### PR TITLE
vendor: faceunlock: switch to TARGET_ARCH build guard base

### DIFF
--- a/config/crdroid.mk
+++ b/config/crdroid.mk
@@ -35,10 +35,12 @@ PRODUCT_PACKAGES += \
 
 # Face Unlock
 TARGET_FACE_UNLOCK_SUPPORTED := false
+ifeq ($(TARGET_ARCH), arm64)
 ifneq ($(TARGET_DISABLE_ALTERNATIVE_FACE_UNLOCK), true)
 PRODUCT_PACKAGES += \
     FaceUnlockService
 TARGET_FACE_UNLOCK_SUPPORTED := true
+endif
 endif
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.face.moto_unlock_service=$(TARGET_FACE_UNLOCK_SUPPORTED)


### PR DESCRIPTION
* Since arm devices are not supported build FaceUnlockService
  only if TARGET_ARCH is arm64