### PR TITLE
build: Add flag for using new clang tools for kernel build

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -206,6 +206,13 @@ ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     ifeq ($(KERNEL_LD),)
         KERNEL_LD :=
     endif
+    ifeq ($(TARGET_KERNEL_USE_CLANG_TOOLS),true)
+        KERNEL_CC += AR=$(TARGET_KERNEL_CLANG_PATH)/bin/llvm-ar
+        KERNEL_CC += NM=$(TARGET_KERNEL_CLANG_PATH)/bin/llvm-nm
+        KERNEL_CC += OBJCOPY=$(TARGET_KERNEL_CLANG_PATH)/bin/llvm-objcopy
+        KERNEL_CC += OBJDUMP=$(TARGET_KERNEL_CLANG_PATH)/bin/llvm-objdump
+        KERNEL_CC += STRIP=$(TARGET_KERNEL_CLANG_PATH)/bin/llvm-strip
+    endif
 endif
 
 ifneq ($(TARGET_KERNEL_MODULES),)


### PR DESCRIPTION
Android still uses gcc tools for kernel build which is kinda sad because almost every kernel can use new clang tools.
Introduce a flag for using new tools.

Signed-off-by: xNombre <kartapolska@gmail.com>