### PR TITLE
crdroid: Fix device name generation for some devices

### DIFF
--- a/build/tools/changelog.sh
+++ b/build/tools/changelog.sh
@@ -17,7 +17,7 @@
 
 Changelog=Changelog.txt
 
-DEVICE=$(echo $TARGET_PRODUCT | cut -d "_" -f2)
+DEVICE=$(echo $TARGET_PRODUCT | sed -e 's/lineage_//g')
 
 if [ -f $Changelog ];
 then


### PR DESCRIPTION
* Fix for "including underscore in product name"
  like sony's Wi-Fi only devices.
  (scorpion_windy, karin_windy etc.)

Change-Id: I5ceed7a2a7f884079de95a32c488032c24457702