### PR TITLE
kernel: Add TARGET_FORCE_PREBUILT_KERNEL flag

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -153,8 +153,21 @@ else
         $(warning **********************************************************)
         $(error "NO KERNEL CONFIG")
     else
-        FULL_KERNEL_BUILD := true
-        KERNEL_BIN := $(TARGET_PREBUILT_INT_KERNEL)
+        ifneq ($(TARGET_FORCE_PREBUILT_KERNEL),)
+            $(warning **********************************************************)
+            $(warning * Kernel source found and configuration was defined      *)
+            $(warning * but prebuilt kernel is being enforced.                 *)
+            $(warning * While there may be a good reason for this,             *)
+            $(warning * THIS IS NOT ADVISED.                                   *)
+            $(warning * Please configure your device to build the kernel       *)
+            $(warning * from source by unsetting TARGET_FORCE_PREBUILT_KERNEL  *)
+            $(warning **********************************************************)
+            FULL_KERNEL_BUILD := false
+            KERNEL_BIN := $(TARGET_PREBUILT_KERNEL)
+        else
+            FULL_KERNEL_BUILD := true
+            KERNEL_BIN := $(TARGET_PREBUILT_INT_KERNEL)
+        endif
     endif
 endif
 

--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -41,9 +41,6 @@ BUILD_TOP := $(shell pwd)
 
 TARGET_AUTO_KDIR := $(shell echo $(TARGET_DEVICE_DIR) | sed -e 's/^device/kernel/g')
 TARGET_KERNEL_SOURCE ?= $(TARGET_AUTO_KDIR)
-ifneq ($(TARGET_PREBUILT_KERNEL),)
-TARGET_KERNEL_SOURCE :=
-endif
 
 TARGET_KERNEL_ARCH := $(strip $(TARGET_KERNEL_ARCH))
 ifeq ($(TARGET_KERNEL_ARCH),)


### PR DESCRIPTION
* TARGET_FORCE_PREBUILT_KERNEL should be useful when you don't have ready kernel sources (OEM releasing broken sources or releasing them lately)
* It lets you use kernel sources for userspace generated headers (generated_kernel_headers) while keeping using prebuilt kernel
* This commit also partially revert commit a836d79, where TARGET_KERNEL_SOURCE would have been unset if TARGET_PREBUILT_KERNEL was defined (we already check in kernel.mk if kernel sources are present anyway)

Change-Id: I84acae890dabb5b9dbd48143ad58f6420c0cef75