### PR TITLE
crdroid: Allow argument to setting device in changelog.sh

### DIFF
--- a/build/tools/changelog.sh
+++ b/build/tools/changelog.sh
@@ -17,7 +17,11 @@
 
 Changelog=Changelog.txt
 
-DEVICE=$(echo $TARGET_PRODUCT | sed -e 's/lineage_//g')
+if [ -z $1 ]; then
+	DEVICE=$(echo $TARGET_PRODUCT | sed -e 's/lineage_//g')
+else
+	DEVICE=$1
+fi
 
 if [ -f $Changelog ];
 then

--- a/build/tools/changelog.sh
+++ b/build/tools/changelog.sh
@@ -17,11 +17,7 @@
 
 Changelog=Changelog.txt
 
-if [ -z $1 ]; then
-	DEVICE=$(echo $TARGET_PRODUCT | sed -e 's/lineage_//g')
-else
-	DEVICE=$1
-fi
+DEVICE=$1
 
 if [ -f $Changelog ];
 then


### PR DESCRIPTION
This change needs for some pattern, like `griffin_dsds`. (`griffin` is the codename of Xperia 1, and `dsds` is "dual sim, dual standby.)
In this pattern, `$DEVICE` expected to be "griffin", but to be "griffin_dsds" in this script currently.
So in this change, get device name from command line argument, in place of generating.