### PR TITLE
config: Remove duplicate prop

### DIFF
--- a/config/common_full_phone.mk
+++ b/config/common_full_phone.mk
@@ -8,8 +8,4 @@ PRODUCT_PACKAGES += \
 # Include Lineage LatinIME dictionaries
 PRODUCT_PACKAGE_OVERLAYS += vendor/lineage/overlay/dictionaries
 
-# Enable support of one-handed mode
-PRODUCT_PRODUCT_PROPERTIES += \
-    ro.support_one_handed_mode=true
-
 $(call inherit-product, vendor/lineage/config/telephony.mk)

--- a/config/crdroid.mk
+++ b/config/crdroid.mk
@@ -5,7 +5,6 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.url.legal.android_privacy=http://www.google.com/intl/%s/mobile/android/basic/privacy.html \
     ro.error.receiver.system.apps=com.google.android.gms \
     ro.setupwizard.enterprise_mode=1 \
-    ro.com.android.dataroaming=false \
     ro.atrace.core.services=com.google.android.gms,com.google.android.gms.ui,com.google.android.gms.persistent \
     ro.setupwizard.rotation_locked=true \
     ro.com.google.ime.theme_id=5 \
@@ -16,9 +15,7 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.setupwizard.mode=OPTIONAL \
     setupwizard.feature.predeferred_enabled=false \
     drm.service.enabled=true \
-    net.tethering.noprovisioning=true \
     persist.sys.dun.override=0 \
-    keyguard.no_require_sim=true \
     persist.sys.disable_rescue=true
 
 # Enable IORap I/O Prefetching


### PR DESCRIPTION
Dataroaming and Keyguard prop already here:
https://github.com/crdroidandroid/android_build/blob/a9f4cd5493ead4134aba6e17e80c81eb104cdf43/target/product/full_base_telephony.mk#L22

Tethering provisioning prop already here:
https://github.com/crdroidandroid/android_vendor_crdroid/blob/6abbd9d45b33c9a6f499eca9a7eac84ef5613e22/config/telephony.mk#L21

One-handed mode prop already here:
https://github.com/crdroidandroid/android_vendor_crdroid/blob/6abbd9d45b33c9a6f499eca9a7eac84ef5613e22/config/crdroid.mk#L30