### PR TITLE
kernel: do not hard-code LD and AR when KERNEL_TOOLCHAIN is set

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -160,8 +160,10 @@ ifeq (,$(filter 5.10, $(TARGET_KERNEL_VERSION)))
     KERNEL_MAKE_FLAGS += HOSTCXX=$(CLANG_PREBUILTS)/bin/clang++
     ifneq ($(TARGET_KERNEL_CLANG_COMPILE), false)
         ifneq ($(TARGET_KERNEL_LLVM_BINUTILS), false)
-            KERNEL_MAKE_FLAGS += LD=$(CLANG_PREBUILTS)/bin/ld.lld
-            KERNEL_MAKE_FLAGS += AR=$(CLANG_PREBUILTS)/bin/llvm-ar
+            ifeq ($(KERNEL_TOOLCHAIN),)
+                KERNEL_MAKE_FLAGS += LD=$(CLANG_PREBUILTS)/bin/ld.lld
+                KERNEL_MAKE_FLAGS += AR=$(CLANG_PREBUILTS)/bin/llvm-ar
+            endif # KERNEL_TOOLCHAIN
         endif
     endif
 else


### PR DESCRIPTION
The LD and AR were hard-coded to CLANG_PREBUILTS, which is clang-r450784d as of writing. If a device builds kernel with a newer version of LLVM/Clang, the hard-coded LLD may encounter unsupported features such as

ld.lld: error: built-in.o(init/main.o): Opaque pointers are only supported in -opaque-pointers mode (Producer: 'LLVM15.0.0git' Reader: 'LLVM 14.0.6git')

Therefore, only hard-code LD and AR when KERNEL_TOOLCHAIN is not set.

Change-Id: Ic707afc3ddf8101a734ccbd9f7a924952a20f6e3
Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>