### PR TITLE
vendor: soong: Add camera_needs_client_info_lib

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -52,6 +52,27 @@ cc_library_headers {
 
 // Target platform agnostic config modules
 soong_config_module_type {
+    name: "camera_needs_client_info_lib",
+    module_type: "cc_defaults",
+    config_namespace: "lineageGlobalVars",
+    bool_variables: ["camera_needs_client_info_lib"],
+    properties: [
+        "cppflags",
+        "shared_libs",
+    ],
+}
+
+camera_needs_client_info_lib {
+    name: "camera_needs_client_info_lib_defaults",
+    soong_config_variables: {
+        camera_needs_client_info_lib: {
+            cppflags: ["-DCAMERA_NEEDS_CLIENT_INFO_LIB"],
+            shared_libs: ["//hardware/oneplus:vendor.oneplus.hardware.camera@1.0"],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "gralloc_10_usage_bits",
     module_type: "cc_defaults",
     config_namespace: "lineageGlobalVars",

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -30,6 +30,7 @@ SOONG_CONFIG_NAMESPACES += lineageGlobalVars
 SOONG_CONFIG_lineageGlobalVars += \
     additional_gralloc_10_usage_bits \
     gralloc_handle_has_reserved_size \
+    camera_needs_client_info_lib \
     needs_camera_boottime \
     uses_oplus_camera \
     uses_nothing_camera \
@@ -59,6 +60,7 @@ endif
 
 # Soong bool variables
 SOONG_CONFIG_lineageGlobalVars_gralloc_handle_has_reserved_size := $(TARGET_GRALLOC_HANDLE_HAS_RESERVED_SIZE)
+SOONG_CONFIG_lineageGlobalVars_camera_needs_client_info_lib := $(TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB)
 SOONG_CONFIG_lineageGlobalVars_needs_camera_boottime := $(TARGET_CAMERA_BOOTTIME_TIMESTAMP)
 SOONG_CONFIG_lineageGlobalVars_uses_oplus_camera := $(TARGET_USES_OPLUS_CAMERA)
 SOONG_CONFIG_lineageGlobalVars_uses_nothing_camera := $(TARGET_USES_NOTHING_CAMERA)


### PR DESCRIPTION
Signed-off-by: firebird11 <hbgassel@gmail.com>
Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
____
Pulled directly from 12.1 branch.

Needed for 60fps video recording on oneplus/sdm845 using OnePlus Camera v3.14.40 (the latest release available for enchilada & fajita). Without it, setting 1080p60 or 4Kp60 video record modes changes the shutter speed to 1/60th for less motion blur, but video is still only captured at 30fps.

See code changes in in android_frameworks_av.