### PR TITLE
Elminate duplicate definition of qti_kernel_headers

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -55,11 +55,6 @@ cc_library_headers {
     defaults: ["generated_kernel_header_defaults"],
 }
 
-cc_library_headers {
-    name: "qti_kernel_headers",
-    defaults: ["generated_kernel_header_defaults"],
-}
-
 // Target platform agnostic config modules
 soong_config_module_type {
     name: "aapt_version_code",


### PR DESCRIPTION
There is qti_kernel_headers in many Android.bp in kernel source. Refer to following link

https://github.com/search?q=org%3Acrdroidandroid+qti_kernel_headers+path%3Abp+cc_library_headers&type=code