### PR TITLE
soong: Add shim_libs_defaults

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -209,6 +209,23 @@ gralloc_handle_ubwcp_format {
 }
 
 soong_config_module_type {
+    name: "target_shim_libs",
+    module_type: "cc_defaults",
+    config_namespace: "lineageGlobalVars",
+    value_variables: ["target_ld_shim_libs"],
+    properties: ["cppflags"],
+}
+
+target_shim_libs {
+    name: "shim_libs_defaults",
+    soong_config_variables: {
+        target_ld_shim_libs: {
+            cppflags: ["-DLD_SHIM_LIBS=\"%s\""],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "vendor_init",
     module_type: "cc_defaults",
     config_namespace: "lineageGlobalVars",


### PR DESCRIPTION
build error: "linker_defaults" depends on undefined module "shim_libs_defaults"