### PR TITLE
Avoid "custom firmware" detection [1/2]

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -925,5 +925,5 @@ function fixup_common_out_dir() {
 export USE_THINLTO_CACHE=true
 
 # Override host metadata to make builds more reproducible and avoid leaking info
-export BUILD_USERNAME=nobody
-export BUILD_HOSTNAME=android-build
+export BUILD_USERNAME=android-build
+export BUILD_HOSTNAME=r-0123456789abcdef-acab

--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -124,6 +124,11 @@ endif
 # Clear this first to prevent accidental poisoning from env
 KERNEL_MAKE_FLAGS :=
 
+# Use "safe" default values for kernel build user & host - matches Pixels, helps avoid detection
+KERNEL_MAKE_FLAGS += \
+    KBUILD_BUILD_USER="build-user" \
+    KBUILD_BUILD_HOST="build-host"
+
 # Add back threads, ninja cuts this to $(getconf _NPROCESSORS_ONLN)/2
 KERNEL_MAKE_FLAGS += -j$(shell getconf _NPROCESSORS_ONLN)
 


### PR DESCRIPTION
[Corresponding patches in android_build_soong as well]

Even if device is appearing as certified in Play Store, some of the "unlocked bootloader/custom firmware" detection SDKs are looking for extra 'not-Google' tells like timestamps not being explicitly in UTC or build user/host props not matching Pixel patterns.

Continue trying to look "normal" so we pass by default.

References:
https://grapheneos.social/@GrapheneOS/113869639765611071
https://review.lineageos.org/q/topic:%2222.2-hide-builder%22
https://dumps.tadiphone.dev/dumps/google/bluejay/-/blob/bluejay-user-15-BP1A.250405.005-13150826-release-keys/system/system/build.prop

Tests:
Before - Attempting to login/signup in Revolut Business app ends in "Custom firmware not supported" screen (even with fresh "Device is certified" status in Play Store)
After - Success getting to login & signup screens after flash/reboot.