### PR TITLE
config: Disable default frame rate limit for games

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -166,6 +166,10 @@ PRODUCT_PACKAGES += \
     SimpleDeviceConfig \
     SimpleSettingsConfig
 
+# Disable default frame rate limit for games
+PRODUCT_PRODUCT_PROPERTIES += \
+    debug.graphics.game_default_frame_rate.disabled=true
+
 # Extra tools in Lineage
 PRODUCT_PACKAGES += \
     bash \


### PR DESCRIPTION
Android 15 limits refresh rate to 60hz for games unless we enable the developer option 'Disable default frame rate for games' manually. Adding this prop enables it by default.